### PR TITLE
fix: 修复被某些考试软件抢占窗口的问题

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "interview-coder-cn",
-  "version": "1.3.0",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "interview-coder-cn",
-      "version": "1.3.0",
+      "version": "1.4.2",
       "hasInstallScript": true,
       "license": "CC BY-NC 4.0",
       "dependencies": {
@@ -13266,9 +13266,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.3.tgz",
-      "integrity": "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
+      "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13277,7 +13277,7 @@
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
         "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.14"
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interview-coder-cn",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "description": "编码面试解题助手，实时截屏并生成解题思路和答案",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,13 +2,20 @@ import 'dotenv/config'
 import { app, BrowserWindow, globalShortcut, dialog } from 'electron'
 import { autoUpdater } from 'electron-updater'
 
+type AbortLikeError = {
+  name?: string
+  code?: string
+  message?: unknown
+}
+
 // Swallow AbortError from user-initiated stream cancellations to keep console clean
 function isAbortError(error: unknown): boolean {
-  const err = error as any
-  return (
-    !!err &&
-    (err.name === 'AbortError' || err.code === 'ABORT_ERR' || /aborted/i.test(String(err.message)))
-  )
+  if (typeof error !== 'object' || error === null) {
+    return false
+  }
+  const err = error as AbortLikeError
+  const message = typeof err.message === 'string' ? err.message : ''
+  return err.name === 'AbortError' || err.code === 'ABORT_ERR' || /aborted/i.test(message)
 }
 
 process.on('unhandledRejection', (error) => {

--- a/src/renderer/src/coder/index.tsx
+++ b/src/renderer/src/coder/index.tsx
@@ -32,7 +32,7 @@ export default function CoderPage() {
     return () => {
       window.api.removeSyncAppStateListener()
     }
-  }, [])
+  }, [syncAppState])
 
   return (
     <>

--- a/src/renderer/src/lib/store/shortcuts.ts
+++ b/src/renderer/src/lib/store/shortcuts.ts
@@ -26,6 +26,14 @@ interface ShortcutsStore extends ShortcutsState {
   resetShortcuts: () => void
 }
 
+type PersistedShortcutsState = {
+  shortcuts?: Record<string, Shortcut>
+}
+
+function isPersistedShortcutsState(value: unknown): value is PersistedShortcutsState {
+  return typeof value === 'object' && value !== null && 'shortcuts' in value
+}
+
 const defaultShortcuts: Record<string, Omit<Shortcut, 'defaultKey'>> = {
   hideOrShowMainWindow: {
     action: 'hideOrShowMainWindow',
@@ -101,8 +109,8 @@ export const useShortcutsStore = create<ShortcutsStore>()(
     {
       name: 'interview-coder-shortcuts',
       version: 2,
-      migrate: (state: any) => {
-        if (!state?.shortcuts) return state
+      migrate: (state: unknown) => {
+        if (!isPersistedShortcutsState(state) || !state.shortcuts) return state as ShortcutsStore
         // Merge in any new default shortcuts that are missing
         const defaults = Object.fromEntries(
           Object.entries(defaultShortcuts).map(([action, shortcut]) => [
@@ -116,7 +124,7 @@ export const useShortcutsStore = create<ShortcutsStore>()(
             ...defaults,
             ...state.shortcuts
           }
-        }
+        } as ShortcutsStore
       }
     }
   )

--- a/src/renderer/src/lib/utils/keyboard.ts
+++ b/src/renderer/src/lib/utils/keyboard.ts
@@ -100,8 +100,14 @@ export function getShortcutAccelerator(event: KeyboardEvent) {
   }
 
   const modifiers: string[] = []
-  if (event.ctrlKey) modifiers.push(isMac ? 'Control' : 'CommandOrControl')
-  if (event.altKey) modifiers.push('Alt')
+  // AltRight on Windows reports AltGraph and toggles ctrlKey, so treat it as plain Alt
+  const isAltGraph =
+    typeof event.getModifierState === 'function' && event.getModifierState('AltGraph')
+  const isCtrlActive = event.ctrlKey && !isAltGraph
+  const isAltActive = event.altKey || isAltGraph
+
+  if (isCtrlActive) modifiers.push(isMac ? 'Control' : 'CommandOrControl')
+  if (isAltActive) modifiers.push('Alt')
   if (event.shiftKey) modifiers.push('Shift')
   if (event.metaKey) modifiers.push(isMac ? 'CommandOrControl' : 'Meta')
   if (modifiers.length === 0) return null


### PR DESCRIPTION
### 修复：增强窗口置顶能力并重构快捷键逻辑

**问题描述**

在 Windows 平台上，当一些具有高优先级的软件（如某些考试客户端、全屏应用）运行时，它们会强制将自己的窗口置于最顶层。这导致本应用通过快捷键 `Alt+H` 唤出时，窗口会闪烁一下然后被覆盖，无法正常使用。此外，快捷键系统在处理 Windows 特有的 `AltGraph` (右Alt) 按键时存在识别问题。

**解决方案**

1.  **引入脉冲式置顶机制**：在 `src/main/shortcuts.ts` 中，当窗口被显示后，会启动一个为期5秒的定时器，以150毫秒的频率持续强制窗口置顶 (`setAlwaysOnTop` + `moveTop`)。这种高频的置顶策略能有效对抗其他应用的抢占行为，确保窗口稳定显示在最前方。

2.  **优化焦点管理**：为了避免唤出窗口时打断用户当前的工作流，现已在 Windows 和 macOS 平台上改用 `showInactive()` 方法来显示窗口。这使得窗口可以在不获取焦点的情况下显示，用户可以继续在之前的应用中输入，体验更流畅。

**其他改进**

在修复核心问题的基础上，还对相关模块进行了以下增强和代码质量提升：

*   **统一左右 Alt 键行为 (Windows)**:
    *   `src/renderer/src/lib/utils/keyboard.ts`: 增加了对 `AltGraph` (右 Alt) 的识别逻辑，避免其被错误地识别为 `Ctrl+Alt` 的组合，确保快捷键在录制和显示时，左右 Alt 键的行为一致。
    *   `src/main/shortcuts.ts`: 在 Windows 平台上，为仅包含 `Alt` 的快捷键组合自动注册一个 `Ctrl+Alt` 的别名。这解决了右 Alt 键无法触发快捷键的问题，并通过记录已注册的快捷键，避免了重复注册导致的内存泄漏。

*   **增强类型安全**:
    *   `src/main/index.ts`: 增加了 `AbortLikeError` 类型守卫，替换了原先的 `any` 类型。现在，应用的生命周期钩子可以精准地识别并忽略由用户主动取消操作（如关闭窗口）造成的预期内异常。
    *   `src/renderer/src/lib/store/shortcuts.ts`: 新增了 `PersistentShortcutsState` 类型守卫，使得 `migrate` 函数不再依赖 `any` 类型，代码更加健壮，同时保留了默认快捷键的合并逻辑。

*   **遵循 React Hooks 规范**:
    *   `src/renderer/src/coder/index.tsx`: 将 `useEffect` 的依赖项数组修正为 `[syncAppState]`，以满足 React Hooks 的 exhaustive-deps 规则，避免潜在的 bug 和不必要的重复渲染。

**测试情况**

*   **平台**: Windows 11
*   **场景**:
    1.  已在会导致窗口抢占问题的邮政考试客户端环境下测试通过。修改后，应用窗口能够稳定地保持在最顶层。
    2.  在 Windows 系统下，分别使用**左 Alt** 和**右 Alt** (AltGraph) 均可正常触发已设置的快捷键。