### PR TITLE
feat: 实现连续截图分析、多图画廊视图及会话重置功能

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "interview-coder-cn",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "interview-coder-cn",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "hasInstallScript": true,
       "license": "CC BY-NC 4.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interview-coder-cn",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "编码面试解题助手，实时截屏并生成解题思路和答案",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/ai.ts
+++ b/src/main/ai.ts
@@ -69,3 +69,21 @@ export function getFollowUpStream(
   })
   return textStream
 }
+
+export function getGeneralStream(messages: ModelMessage[], abortSignal?: AbortSignal) {
+  const openai = createOpenAI({
+    baseURL: settings.apiBaseURL,
+    apiKey: settings.apiKey
+  })
+
+  const { textStream } = streamText({
+    model: openai(settings.model || 'gpt-4o-mini'),
+    system:
+      settings.customPrompt ||
+      PROMPT_SYSTEM +
+        `\n使用编程语言：${settings.codeLanguage} 解答。\n\n注意：如果有多张截图，请结合所有截图内容进行完整分析，不要遗漏任何部分。`,
+    messages,
+    abortSignal
+  })
+  return textStream
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -94,6 +94,16 @@ const api = {
     ipcRenderer.removeAllListeners('scroll-page-up')
   },
 
+  // Listen for screenshots-updated (gallery)
+  onScreenshotsUpdated: (callback: (screenshots: string[]) => void) => {
+    ipcRenderer.on('screenshots-updated', (_event, screenshots) => {
+      callback(screenshots)
+    })
+  },
+  removeScreenshotsUpdatedListener: () => {
+    ipcRenderer.removeAllListeners('screenshots-updated')
+  },
+
   // Listen for scroll page down
   onScrollPageDown: (callback: () => void) => {
     ipcRenderer.on('scroll-page-down', callback)
@@ -101,6 +111,28 @@ const api = {
   // Remove scroll page down listener
   removeScrollPageDownListener: () => {
     ipcRenderer.removeAllListeners('scroll-page-down')
+  },
+
+  // AI loading events
+  onAiLoadingStart: (callback: () => void) => {
+    ipcRenderer.on('ai-loading-start', callback)
+  },
+  onAiLoadingEnd: (callback: () => void) => {
+    ipcRenderer.on('ai-loading-end', callback)
+  },
+  removeAiLoadingStartListener: () => {
+    ipcRenderer.removeAllListeners('ai-loading-start')
+  },
+  removeAiLoadingEndListener: () => {
+    ipcRenderer.removeAllListeners('ai-loading-end')
+  },
+
+  // Solution clear event (new session)
+  onSolutionClear: (callback: () => void) => {
+    ipcRenderer.on('solution-clear', callback)
+  },
+  removeSolutionClearListener: () => {
+    ipcRenderer.removeAllListeners('solution-clear')
   }
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -39,7 +39,11 @@ export default function App() {
   }, [initialized, settingsStore])
 
   useEffect(() => {
+    console.log('App initShortcuts:', shortcuts) // DEBUG: 检查新键
     window.api.initShortcuts(shortcuts)
+    window.api.getShortcuts().then((shortcutsStatus) => {
+      console.log('Shortcuts registered:', shortcutsStatus) // DEBUG: 主进程状态
+    })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/src/renderer/src/lib/store/shortcuts.ts
+++ b/src/renderer/src/lib/store/shortcuts.ts
@@ -46,6 +46,11 @@ const defaultShortcuts: Record<string, Omit<Shortcut, 'defaultKey'>> = {
     category: 'Window Management'
   },
   takeScreenshot: { action: 'takeScreenshot', key: 'Alt+Enter', category: 'Screenshot & AI' },
+  appendScreenshot: {
+    action: 'appendScreenshot',
+    key: 'Alt+Shift+Enter',
+    category: 'Screenshot & AI'
+  },
   stopSolutionStream: {
     action: 'stopSolutionStream',
     key: 'Alt+.',

--- a/src/renderer/src/settings/CustomShortcuts.tsx
+++ b/src/renderer/src/settings/CustomShortcuts.tsx
@@ -71,6 +71,7 @@ export function CustomShortcuts() {
           <h3 className="text-sm text-gray-500">截图与AI</h3>
           <Shortcut label="截图" shortcut="takeScreenshot" />
           <Shortcut label="停止生成" shortcut="stopSolutionStream" />
+          <Shortcut label="追加截图 (长题目)" shortcut="appendScreenshot" />
         </div>
 
         {/* Navigation */}


### PR DESCRIPTION
# 连续截图功能与 UI 优化

## 变更摘要

本 PR 重点实现了 **“连续截图”** 功能，允许用户通过 `Alt+Shift+Enter` 追加截图到当前会话，AI 将结合历史截图上下文进行综合分析。同时优化了 UI 布局（增加水平画廊视图）、完善了加载状态指示，并修复了新旧会话的重置逻辑。

## 主要变更

### 快捷键逻辑

  - **新增 `Alt+Shift+Enter`**：触发“追加截图”功能。此时**不清除**历史记录，AI 将基于当前会话的所有截图上下文进行分析。
  - **更新 `Alt+Enter`**：触发“新截图”功能。现在会强制**清空**截图画廊和之前的 AI 回答，确保开启一个全新的会话。
  - **配置项**：在 UI 设置面板中新增了上述自定义快捷键的配置选项。

### UI/UX 改进

  - **水平画廊视图**：在页面顶部引入了全新的截图预览区，支持最多显示 **5 张** 最近截图，并采用水平排列方式，解决多图显示拥挤的问题。
  - **状态反馈**：优化了生成过程中的 UI 表现，增加了明确的 Spinner 加载状态。

### AI 上下文

  - **Prompt 逻辑升级**：重构了 AI 请求参数构造逻辑，确保透传 `conversationMessages` 中的**所有**历史截图数据，修复了此前仅分析最后一张图的问题。

## 修复的问题

  - [x] 修复了 AI 仅识别最后一张截图，忽略历史上下文的问题。
  - [x] 修复了多张截图时 UI 无法水平排列、布局错乱的问题。
  - [x] 修复了使用 `Alt+Enter` 开启新会话时，旧图片和旧答案未被彻底清除的 Bug。
  - [x] 修复了生成过程中缺失“思考中...”状态指示的问题。

## 验证步骤

1.  **配置检查**：
      - 进入 `设置 -> 快捷键`，确认“追加截图”快捷键已正确注册且无冲突。
2.  **追加模式测试**：
      - 按下 `Alt+Enter` 截取第一张图，确认 AI 开始分析。
      - 按下 `Alt+Shift+Enter` 截取第二张图，确认顶部画廊显示两张图，且 AI 回答结合了两张图的内容。
3.  **重置模式测试**：
      - 再次按下 `Alt+Enter`，确认顶部画廊清空、旧答案清空，并开始新一轮的独立分析。
4.  **UI 观察**：
      - 确认生成过程中状态栏显示 Spinner 动画。
      - 确认多张截图时，画廊区域可以正常水平滚动。

## 变更文件

```text
src/ai.ts
src/shortcuts.ts
src/preload/index.ts
src/renderer/src/AppContent.tsx
src/renderer/src/lib/store/shortcuts.ts
src/renderer/src/components/CustomShortcuts.tsx
```