### PR TITLE
feat: add click-through overlay toolbar

### DIFF
--- a/src/main/ai.ts
+++ b/src/main/ai.ts
@@ -11,7 +11,7 @@ function getSystemPrompt(extra?: string) {
 function getModel(_settings: AppSettings) {
   const fallbackModel = settings.apiBaseURL.includes('siliconflow')
     ? 'Qwen/Qwen3-VL-32B-Instruct'
-    : 'gpt-5-mini'
+    : 'gpt-5.4'
   return _settings.model || fallbackModel
 }
 

--- a/src/main/index.d.ts
+++ b/src/main/index.d.ts
@@ -2,4 +2,5 @@ import type { BrowserWindow } from 'electron'
 
 declare global {
   var mainWindow: BrowserWindow | null
+  var toolbarWindow: BrowserWindow | null
 }

--- a/src/main/main-window.ts
+++ b/src/main/main-window.ts
@@ -1,7 +1,11 @@
 import { join } from 'node:path'
-import { shell, BrowserWindow } from 'electron'
+import { shell, BrowserWindow, screen } from 'electron'
 import { is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
+
+const TOOLBAR_WIDTH = 504
+const TOOLBAR_HEIGHT = 52
+const TOOLBAR_INSET = 4
 
 export function applyContentProtection(window: BrowserWindow, forceReset = false): void {
   if (!window || window.isDestroyed()) return
@@ -36,6 +40,31 @@ export function createWindow(): void {
 
   // Store reference to mainWindow globally
   global.mainWindow = mainWindow
+  const toolbarWindow = createToolbarWindow(mainWindow)
+  global.toolbarWindow = toolbarWindow
+
+  const syncToolbarBounds = () => {
+    if (toolbarWindow.isDestroyed() || mainWindow.isDestroyed()) return
+    const mainBounds = mainWindow.getBounds()
+    const workArea = screen.getDisplayMatching(mainBounds).workArea
+    toolbarWindow.setBounds({
+      x: Math.min(Math.max(mainBounds.x, workArea.x), workArea.x + workArea.width - TOOLBAR_WIDTH),
+      y: Math.max(workArea.y, mainBounds.y - TOOLBAR_HEIGHT - TOOLBAR_INSET),
+      width: TOOLBAR_WIDTH,
+      height: TOOLBAR_HEIGHT
+    })
+  }
+
+  mainWindow.on('move', syncToolbarBounds)
+  mainWindow.on('resize', syncToolbarBounds)
+  mainWindow.on('show', () => {
+    syncToolbarBounds()
+  })
+  mainWindow.on('hide', () => toolbarWindow.hide())
+  mainWindow.on('closed', () => {
+    if (!toolbarWindow.isDestroyed()) toolbarWindow.close()
+    global.toolbarWindow = null
+  })
 
   mainWindow.setMenuBarVisibility(false)
 
@@ -82,4 +111,36 @@ export function createWindow(): void {
   } else {
     mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
   }
+}
+
+function createToolbarWindow(parent: BrowserWindow): BrowserWindow {
+  const toolbarWindow = new BrowserWindow({
+    width: TOOLBAR_WIDTH,
+    height: TOOLBAR_HEIGHT,
+    frame: false,
+    transparent: true,
+    hasShadow: false,
+    focusable: false,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    show: false,
+    parent,
+    webPreferences: {
+      preload: join(__dirname, '../preload/index.js'),
+      sandbox: false
+    }
+  })
+
+  toolbarWindow.setMenuBarVisibility(false)
+  toolbarWindow.setAlwaysOnTop(true, 'screen-saver', 2)
+  toolbarWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
+  applyContentProtection(toolbarWindow)
+
+  if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
+    toolbarWindow.loadURL(`${process.env['ELECTRON_RENDERER_URL']}#/toolbar`)
+  } else {
+    toolbarWindow.loadFile(join(__dirname, '../renderer/index.html'), { hash: 'toolbar' })
+  }
+
+  return toolbarWindow
 }

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -35,7 +35,7 @@ ipcMain.handle('selectScreenshotDir', async () => {
 export const settings = {
   apiBaseURL: process.env.API_BASE_URL || '',
   apiKey: process.env.API_KEY || '',
-  model: process.env.MODEL || '',
+  model: process.env.MODEL || 'gpt-5.4',
   customPrompt: '',
   screenshotAutoSave: false,
   screenshotDir: '',

--- a/src/main/shortcuts.ts
+++ b/src/main/shortcuts.ts
@@ -97,6 +97,11 @@ function applyTopMost(win: BrowserWindow, aggressive = true) {
   if (!win || win.isDestroyed()) return
   win.setAlwaysOnTop(true, 'screen-saver', FRONT_RELATIVE_LEVEL)
   if (aggressive) win.moveTop()
+
+  if (state.ignoreMouse && global.toolbarWindow && !global.toolbarWindow.isDestroyed()) {
+    global.toolbarWindow.setAlwaysOnTop(true, 'screen-saver', FRONT_RELATIVE_LEVEL + 1)
+    if (aggressive) global.toolbarWindow.moveTop()
+  }
 }
 
 /**
@@ -155,6 +160,7 @@ function softHideWindow(window: BrowserWindow) {
   window.setOpacity(0)
   window.setIgnoreMouseEvents(true)
   window.setBounds(getOffscreenBounds(window))
+  global.toolbarWindow?.hide()
 }
 
 function restoreSoftHiddenWindow(window: BrowserWindow) {
@@ -167,6 +173,9 @@ function restoreSoftHiddenWindow(window: BrowserWindow) {
 
   isWindowSoftHidden = false
   softHiddenBounds = null
+  if (state.inCoderPage) {
+    global.toolbarWindow?.showInactive()
+  }
   keepWindowInFront(window)
 }
 
@@ -178,6 +187,9 @@ function showMainWindow(window: BrowserWindow) {
   }
 
   applyContentProtection(window, process.platform === 'win32')
+  if (state.inCoderPage) {
+    global.toolbarWindow?.showInactive()
+  }
   keepWindowInFront(window)
 }
 
@@ -502,6 +514,7 @@ const callbacks: Record<string, () => void> = {
     if (!mainWindow || mainWindow.isDestroyed() || !state.inCoderPage) return
     state.ignoreMouse = !state.ignoreMouse
     mainWindow.setIgnoreMouseEvents(state.ignoreMouse)
+    global.toolbarWindow?.showInactive()
     mainWindow.webContents.send('sync-app-state', state)
   },
 
@@ -566,6 +579,23 @@ const callbacks: Record<string, () => void> = {
     mainWindow.webContents.send('transcription-cleared')
   }
 }
+
+const clickableActions = new Set([
+  'takeScreenshot',
+  'appendScreenshot',
+  'stopSolutionStream',
+  'ignoreOrEnableMouse',
+  'increaseOpacity',
+  'decreaseOpacity',
+  'pageUp',
+  'pageDown',
+  'moveMainWindowUp',
+  'moveMainWindowDown',
+  'moveMainWindowLeft',
+  'moveMainWindowRight',
+  'toggleTranscription',
+  'clearTranscription'
+])
 
 function unregisterShortcut(action: string) {
   const shortcut = shortcuts[action]
@@ -647,6 +677,22 @@ ipcMain.handle('stopSolutionStream', () => {
   if (!currentStreamContext) return false
   abortCurrentStream('user')
   return true
+})
+
+ipcMain.handle('triggerAction', (_event, action: string) => {
+  if (!clickableActions.has(action)) return false
+  callbacks[action]?.()
+  return true
+})
+
+ipcMain.handle('setToolbarVisible', (_event, visible: boolean) => {
+  const toolbarWindow = global.toolbarWindow
+  if (!toolbarWindow || toolbarWindow.isDestroyed()) return
+  if (visible) {
+    toolbarWindow.showInactive()
+  } else {
+    toolbarWindow.hide()
+  }
 })
 
 ipcMain.handle('sendFollowUpQuestion', async (_event, question: string) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -33,6 +33,26 @@ const api = {
   updateShortcuts: (shortcuts: { action: string; key: string }[]) =>
     ipcRenderer.invoke('updateShortcuts', shortcuts),
 
+  // Trigger the small set of user-facing actions exposed by the overlay toolbar.
+  triggerAction: (
+    action:
+      | 'takeScreenshot'
+      | 'appendScreenshot'
+      | 'stopSolutionStream'
+      | 'ignoreOrEnableMouse'
+      | 'increaseOpacity'
+      | 'decreaseOpacity'
+      | 'pageUp'
+      | 'pageDown'
+      | 'moveMainWindowUp'
+      | 'moveMainWindowDown'
+      | 'moveMainWindowLeft'
+      | 'moveMainWindowRight'
+      | 'toggleTranscription'
+      | 'clearTranscription'
+  ) => ipcRenderer.invoke('triggerAction', action),
+  setToolbarVisible: (visible: boolean) => ipcRenderer.invoke('setToolbarVisible', visible),
+
   // Listen for window opacity adjustments triggered by shortcuts
   onAdjustOpacity: (callback: (delta: number) => void) => {
     ipcRenderer.on('adjust-opacity', (_event, delta) => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react'
-import { HashRouter, Routes, Route } from 'react-router'
+import { HashRouter, Routes, Route, useLocation } from 'react-router'
 import { Toaster } from 'sonner'
 import CoderPage from '@/coder'
 import SettingsPage from '@/settings'
 import HelpPage from '@/help'
+import { OverlayToolbar } from '@/coder/OverlayToolbar'
 import { useSettingsStore } from '@/lib/store/settings'
 import { useShortcutsStore } from '@/lib/store/shortcuts'
 import { getCloneableFields } from '@/lib/utils'
@@ -50,14 +51,27 @@ export default function App() {
   return (
     <>
       <HashRouter>
+        <ToolbarVisibilityController />
         <Routes>
           <Route index element={<CoderPage />} />
           <Route path="settings" element={<SettingsPage />} />
           <Route path="help" element={<HelpPage />} />
+          <Route path="toolbar" element={<OverlayToolbar />} />
         </Routes>
       </HashRouter>
 
       <Toaster />
     </>
   )
+}
+
+function ToolbarVisibilityController() {
+  const location = useLocation()
+
+  useEffect(() => {
+    if (location.pathname === '/toolbar') return
+    void window.api.setToolbarVisible(location.pathname === '/')
+  }, [location.pathname])
+
+  return null
 }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -40,3 +40,16 @@
 .transcription-scroll:hover::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.3);
 }
+
+.overlay-toolbar {
+  @apply flex h-[52px] items-center gap-1 rounded-md bg-gray-700/90 p-2 text-white;
+  -webkit-app-region: no-drag;
+}
+
+.overlay-toolbar button {
+  @apply size-8 shrink-0 cursor-default hover:bg-white/15 hover:text-white;
+}
+
+body:has(.overlay-toolbar) {
+  overflow: hidden;
+}

--- a/src/renderer/src/coder/AppHeader.tsx
+++ b/src/renderer/src/coder/AppHeader.tsx
@@ -1,4 +1,4 @@
-import { SettingsIcon, HelpCircle, X } from 'lucide-react'
+import { HelpCircle, SettingsIcon, X } from 'lucide-react'
 import { useNavigate } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { useAppStore } from '@/lib/store/app'
@@ -9,7 +9,7 @@ export function AppHeader() {
 
   return (
     <div id="app-header" className="flex items-center text-white">
-      <div className="mx-auto pl-12">截屏解题助手</div>
+      <div className="mx-auto">截屏解题助手</div>
       <div className={`actions ${ignoreMouse ? 'pointer-events-none' : ''}`}>
         <Button
           variant="ghost"

--- a/src/renderer/src/coder/OverlayToolbar.tsx
+++ b/src/renderer/src/coder/OverlayToolbar.tsx
@@ -1,0 +1,49 @@
+import {
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  Camera,
+  ChevronDown,
+  ChevronUp,
+  CircleStop,
+  ImagePlus,
+  Mic,
+  MousePointer2,
+  Sun,
+  SunDim
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+const toolbarActions = [
+  { action: 'takeScreenshot', Icon: Camera },
+  { action: 'appendScreenshot', Icon: ImagePlus },
+  { action: 'stopSolutionStream', Icon: CircleStop },
+  { action: 'ignoreOrEnableMouse', Icon: MousePointer2 },
+  { action: 'pageUp', Icon: ChevronUp },
+  { action: 'pageDown', Icon: ChevronDown },
+  { action: 'moveMainWindowUp', Icon: ArrowUp },
+  { action: 'moveMainWindowLeft', Icon: ArrowLeft },
+  { action: 'moveMainWindowDown', Icon: ArrowDown },
+  { action: 'moveMainWindowRight', Icon: ArrowRight },
+  { action: 'increaseOpacity', Icon: Sun },
+  { action: 'decreaseOpacity', Icon: SunDim },
+  { action: 'toggleTranscription', Icon: Mic }
+] as const
+
+export function OverlayToolbar() {
+  return (
+    <div className="overlay-toolbar">
+      {toolbarActions.map(({ action, Icon }, index) => (
+        <Button
+          key={`${action}-${index}`}
+          variant="ghost"
+          size="icon"
+          onClick={() => void window.api.triggerAction(action)}
+        >
+          <Icon />
+        </Button>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/lib/store/settings.ts
+++ b/src/renderer/src/lib/store/settings.ts
@@ -91,7 +91,7 @@ interface SettingsStore extends Settings {
 const defaultSettings: Settings = {
   apiBaseURL: '',
   apiKey: '',
-  model: '',
+  model: 'gpt-5.4',
   customModels: [],
   customPrompt: PRESET_SCENE_PROMPTS[CODING_SCENE_ID],
   scenes: createPresetScenes(),
@@ -169,7 +169,7 @@ export const useSettingsStore = create<SettingsStore>()(
     }),
     {
       name: 'interview-coder-settings',
-      version: 7,
+      version: 8,
       migrate: (persisted, version) => {
         const state = persisted as Partial<Settings>
         // Drop the legacy codeLanguage field (language now lives in the prompt text)
@@ -185,6 +185,9 @@ export const useSettingsStore = create<SettingsStore>()(
             activeSceneId = id
           }
           return { ...state, scenes, activeSceneId }
+        }
+        if (version < 8 && !state.model) {
+          state.model = 'gpt-5.4'
         }
         return state
       },

--- a/src/renderer/src/settings/SelectModel.tsx
+++ b/src/renderer/src/settings/SelectModel.tsx
@@ -17,6 +17,7 @@ const defaultModels = [
   { value: 'Qwen/Qwen3-VL-32B-Instruct', label: 'Qwen/Qwen3-VL-32B-Instruct' },
   { value: 'Qwen/Qwen3-VL-8B-Thinking', label: 'Qwen/Qwen3-VL-8B-Thinking' },
   { value: 'zai-org/GLM-4.5V', label: 'zai-org/GLM-4.5V' },
+  { value: 'gpt-5.4', label: 'gpt-5.4' },
   { value: 'gpt-5-mini', label: 'gpt-5-mini' },
   { value: 'gpt-5.5', label: 'gpt-5.5' }
 ]


### PR DESCRIPTION
在主窗口上方添加一个工具栏，通过按钮来点击触发截图、上下滚动、移动窗口等功能。工具栏录屏时同样不可见，且在开启屏幕透传后仍然可以被点击，不会引发切屏检测，取代之前必须通过快捷键来触发各个功能，以防检测按键异常