### PR TITLE
feat: 支持动态开关窗口大小调整

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,6 +29,7 @@ process.on('uncaughtException', (error) => {
 import { electronApp, optimizer } from '@electron-toolkit/utils'
 import './shortcuts'
 import './transcription'
+import './window-resize'
 import { createWindow } from './main-window'
 import { initAutoUpdater } from './auto-updater'
 import { applyDockVisibility } from './settings'

--- a/src/main/main-window.ts
+++ b/src/main/main-window.ts
@@ -23,6 +23,8 @@ export function createWindow(): void {
     frame: false,
     transparent: true,
     hasShadow: false,
+    // Native resize toggling breaks transparency on Windows; renderer handles own resizing.
+    resizable: false,
     alwaysOnTop: true,
     skipTaskbar: true,
     hiddenInMissionControl: true,

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -13,8 +13,8 @@ ipcMain.handle('updateAppSettings', (_event, _settings) => {
   if ('opacity' in _settings) {
     setToolbarOpacity(settings.opacity)
   }
-  if ('toolbarHoverDelay' in _settings) {
-    syncToolbarSettings(settings.toolbarHoverDelay)
+  if ('toolbarHoverDelay' in _settings || 'resizable' in _settings) {
+    syncToolbarSettings(settings.toolbarHoverDelay, settings.resizable)
   }
 })
 
@@ -46,10 +46,11 @@ export const settings = {
   customPrompt: '',
   /** Kept in sync with the renderer so the overlay toolbar can match the main window */
   opacity: 0.8,
+  /** Renderer owns this preference; the default is enabled */
+  resizable: true,
   /**
    * Dwell time in ms before hovering a toolbar button fires it; 0 disables hover
-   * triggering. The real default lives in the renderer store: App.tsx fills blank
-   * renderer fields from here, so a truthy default would overwrite a user's "off".
+   * triggering. The renderer owns the persisted value and syncs it here.
    */
   toolbarHoverDelay: 0,
   screenshotAutoSave: false,

--- a/src/main/shortcuts.ts
+++ b/src/main/shortcuts.ts
@@ -519,6 +519,12 @@ const callbacks: Record<string, () => void> = {
     mainWindow.webContents.send('sync-app-state', state)
   },
 
+  toggleWindowResizable: () => {
+    const mainWindow = global.mainWindow
+    if (!mainWindow || mainWindow.isDestroyed()) return
+    mainWindow.webContents.send('toggle-window-resizable')
+  },
+
   increaseOpacity: () => {
     adjustOpacity(OPACITY_STEP)
   },
@@ -586,6 +592,7 @@ const clickableActions = new Set([
   'appendScreenshot',
   'stopSolutionStream',
   'ignoreOrEnableMouse',
+  'toggleWindowResizable',
   'increaseOpacity',
   'decreaseOpacity',
   'pageUp',

--- a/src/main/toolbar-window.ts
+++ b/src/main/toolbar-window.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path'
 import { BrowserWindow, screen } from 'electron'
 import { is } from '@electron-toolkit/utils'
 
-const TOOLBAR_WIDTH = 504
+const TOOLBAR_WIDTH = 540
 const TOOLBAR_HEIGHT = 52
 const TOOLBAR_INSET = 4
 /** Mirrors the renderer's default opacity setting, until the renderer syncs the real one */
@@ -25,6 +25,8 @@ export function createToolbarWindow(parent: BrowserWindow): void {
     frame: false,
     transparent: true,
     hasShadow: false,
+    // Native resize toggling breaks transparency on Windows; renderer handles own resizing.
+    resizable: false,
     // Clicking a button must never pull focus away from what the user is doing
     focusable: false,
     alwaysOnTop: true,
@@ -119,9 +121,9 @@ export function setToolbarOpacity(opacity: number): void {
  * The toolbar lives in its own renderer, so it never sees the settings store
  * updates made in the main window; push the ones it needs over IPC instead.
  */
-export function syncToolbarSettings(hoverDelay: number): void {
+export function syncToolbarSettings(hoverDelay: number, resizable: boolean): void {
   if (!toolbarWindow || toolbarWindow.isDestroyed()) return
-  toolbarWindow.webContents.send('sync-toolbar-settings', { hoverDelay })
+  toolbarWindow.webContents.send('sync-toolbar-settings', { hoverDelay, resizable })
 }
 
 /** Reclaim the top spot alongside the main window, without ever revealing a hidden toolbar */

--- a/src/main/window-resize.ts
+++ b/src/main/window-resize.ts
@@ -1,0 +1,52 @@
+import { BrowserWindow, ipcMain, type Rectangle } from 'electron'
+
+export type ResizeDirection = 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw'
+
+type ResizeState = {
+  window: BrowserWindow
+  direction: ResizeDirection
+  startX: number
+  startY: number
+  bounds: Rectangle
+}
+
+const MIN_WIDTH = 200
+const MIN_HEIGHT = 52
+let resizeState: ResizeState | null = null
+
+ipcMain.on('window-resize-start', (event, direction: ResizeDirection, x: number, y: number) => {
+  const window = BrowserWindow.fromWebContents(event.sender)
+  if (!window || window.isDestroyed()) return
+  resizeState = { window, direction, startX: x, startY: y, bounds: window.getBounds() }
+})
+
+ipcMain.on('window-resize-move', (event, x: number, y: number) => {
+  if (!resizeState || resizeState.window.webContents !== event.sender) return
+  resizeState.window.setBounds(resizeBounds(resizeState, x, y))
+})
+
+ipcMain.on('window-resize-stop', (event) => {
+  if (resizeState?.window.webContents === event.sender) resizeState = null
+})
+
+function resizeBounds(state: ResizeState, x: number, y: number): Rectangle {
+  const { bounds, direction, startX, startY } = state
+  const dx = x - startX
+  const dy = y - startY
+  let { x: left, y: top, width, height } = bounds
+
+  if (direction.includes('e')) width = Math.max(MIN_WIDTH, width + dx)
+  if (direction.includes('s')) height = Math.max(MIN_HEIGHT, height + dy)
+  if (direction.includes('w')) {
+    const nextWidth = Math.max(MIN_WIDTH, width - dx)
+    left += width - nextWidth
+    width = nextWidth
+  }
+  if (direction.includes('n')) {
+    const nextHeight = Math.max(MIN_HEIGHT, height - dy)
+    top += height - nextHeight
+    height = nextHeight
+  }
+
+  return { x: left, y: top, width, height }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,6 +11,22 @@ const api = {
   updateAppSettings: (settings: Partial<AppSettings>) =>
     ipcRenderer.invoke('updateAppSettings', settings),
 
+  // Resize transparent frameless windows without toggling Electron's native resizable style
+  startWindowResize: (
+    direction: 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw',
+    screenX: number,
+    screenY: number
+  ) => ipcRenderer.send('window-resize-start', direction, screenX, screenY),
+  moveWindowResize: (screenX: number, screenY: number) =>
+    ipcRenderer.send('window-resize-move', screenX, screenY),
+  stopWindowResize: () => ipcRenderer.send('window-resize-stop'),
+  onToggleWindowResizable: (callback: () => void) => {
+    ipcRenderer.on('toggle-window-resizable', callback)
+  },
+  removeToggleWindowResizableListener: () => {
+    ipcRenderer.removeAllListeners('toggle-window-resizable')
+  },
+
   // Update app state
   updateAppState: (state: Partial<AppState>) => ipcRenderer.invoke('updateAppState', state),
   // Listen for app state
@@ -40,6 +56,7 @@ const api = {
       | 'appendScreenshot'
       | 'stopSolutionStream'
       | 'ignoreOrEnableMouse'
+      | 'toggleWindowResizable'
       | 'increaseOpacity'
       | 'decreaseOpacity'
       | 'pageUp'
@@ -54,7 +71,9 @@ const api = {
   setToolbarVisible: (visible: boolean) => ipcRenderer.invoke('setToolbarVisible', visible),
 
   // Settings the toolbar window needs, pushed from main (its own store is a separate copy)
-  onSyncToolbarSettings: (callback: (settings: { hoverDelay: number }) => void) => {
+  onSyncToolbarSettings: (
+    callback: (settings: { hoverDelay: number; resizable: boolean }) => void
+  ) => {
     ipcRenderer.on('sync-toolbar-settings', (_event, settings) => {
       callback(settings)
     })

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -8,6 +8,7 @@ import { OverlayToolbar } from '@/coder/OverlayToolbar'
 import { useSettingsStore } from '@/lib/store/settings'
 import { useShortcutsStore } from '@/lib/store/shortcuts'
 import { getCloneableFields } from '@/lib/utils'
+import { WindowResizeHandles } from '@/components/WindowResizeHandles'
 
 export default function App() {
   const [initialized, setInitialized] = useState(false)
@@ -52,6 +53,7 @@ export default function App() {
     <>
       <HashRouter>
         <ToolbarVisibilityController />
+        <WindowResizeController initialized={initialized} />
         <Routes>
           <Route index element={<CoderPage />} />
           <Route path="settings" element={<SettingsPage />} />
@@ -63,6 +65,23 @@ export default function App() {
       <Toaster />
     </>
   )
+}
+
+function WindowResizeController({ initialized }: { initialized: boolean }) {
+  const location = useLocation()
+  const resizable = useSettingsStore((state) => state.resizable)
+  const updateSetting = useSettingsStore((state) => state.updateSetting)
+
+  useEffect(() => {
+    if (!initialized || location.pathname === '/toolbar') return
+    window.api.onToggleWindowResizable(() =>
+      updateSetting('resizable', !useSettingsStore.getState().resizable)
+    )
+    return window.api.removeToggleWindowResizableListener
+  }, [initialized, location.pathname, updateSetting])
+
+  if (location.pathname === '/toolbar') return null
+  return <WindowResizeHandles enabled={resizable} />
 }
 
 function ToolbarVisibilityController() {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -65,6 +65,66 @@
   }
 }
 
+.window-resize-handle {
+  position: fixed;
+  z-index: 2147483647;
+  -webkit-app-region: no-drag;
+  touch-action: none;
+}
+.window-resize-n,
+.window-resize-s {
+  left: 10px;
+  right: 10px;
+  height: 6px;
+  cursor: ns-resize;
+}
+.window-resize-e,
+.window-resize-w {
+  top: 10px;
+  bottom: 10px;
+  width: 6px;
+  cursor: ew-resize;
+}
+.window-resize-n {
+  top: 0;
+}
+.window-resize-s {
+  bottom: 0;
+}
+.window-resize-e {
+  right: 0;
+}
+.window-resize-w {
+  left: 0;
+}
+.window-resize-ne,
+.window-resize-se,
+.window-resize-sw,
+.window-resize-nw {
+  width: 10px;
+  height: 10px;
+}
+.window-resize-ne {
+  top: 0;
+  right: 0;
+  cursor: nesw-resize;
+}
+.window-resize-se {
+  right: 0;
+  bottom: 0;
+  cursor: nwse-resize;
+}
+.window-resize-sw {
+  bottom: 0;
+  left: 0;
+  cursor: nesw-resize;
+}
+.window-resize-nw {
+  top: 0;
+  left: 0;
+  cursor: nwse-resize;
+}
+
 /* The toolbar window holds nothing but the toolbar, so it must never scroll */
 body:has(.overlay-toolbar-root) {
   overflow: hidden;

--- a/src/renderer/src/coder/OverlayToolbar.tsx
+++ b/src/renderer/src/coder/OverlayToolbar.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { TOOLBAR_ACTIONS, type ToolbarActionName } from '@/lib/toolbar-actions'
 import type { LucideIcon } from 'lucide-react'
+import { WindowResizeHandles } from '@/components/WindowResizeHandles'
 
 /**
  * Toolbar rendered in its own always-on-top window above the main window.
@@ -10,14 +11,17 @@ import type { LucideIcon } from 'lucide-react'
  */
 export function OverlayToolbar() {
   const [hoverDelay, setHoverDelay] = useState(0)
+  const [resizable, setResizable] = useState(true)
 
   // This window has its own settings store copy, so main pushes the live value
   useEffect(() => {
     window.api.getAppSettings().then((settings) => {
       setHoverDelay(settings.toolbarHoverDelay || 0)
+      setResizable(settings.resizable)
     })
-    window.api.onSyncToolbarSettings(({ hoverDelay }) => {
+    window.api.onSyncToolbarSettings(({ hoverDelay, resizable }) => {
       setHoverDelay(hoverDelay || 0)
+      setResizable(resizable)
     })
     return () => {
       window.api.removeSyncToolbarSettingsListener()
@@ -29,6 +33,7 @@ export function OverlayToolbar() {
       {TOOLBAR_ACTIONS.map(({ action, Icon }) => (
         <ToolbarButton key={action} action={action} Icon={Icon} hoverDelay={hoverDelay} />
       ))}
+      <WindowResizeHandles enabled={resizable} />
     </div>
   )
 }

--- a/src/renderer/src/components/WindowResizeHandles.tsx
+++ b/src/renderer/src/components/WindowResizeHandles.tsx
@@ -1,0 +1,37 @@
+import type { PointerEvent as ReactPointerEvent } from 'react'
+
+type ResizeDirection = 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw'
+
+const directions: ResizeDirection[] = ['n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw']
+
+export function WindowResizeHandles({ enabled }: { enabled: boolean }) {
+  if (!enabled) return null
+
+  const startResize = (event: ReactPointerEvent<HTMLDivElement>, direction: ResizeDirection) => {
+    if (event.button !== 0) return
+    event.currentTarget.setPointerCapture(event.pointerId)
+    window.api.startWindowResize(direction, event.screenX, event.screenY)
+  }
+
+  const moveResize = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.hasPointerCapture(event.pointerId)) return
+    window.api.moveWindowResize(event.screenX, event.screenY)
+  }
+
+  const stopResize = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.hasPointerCapture(event.pointerId)) return
+    event.currentTarget.releasePointerCapture(event.pointerId)
+    window.api.stopWindowResize()
+  }
+
+  return directions.map((direction) => (
+    <div
+      key={direction}
+      className={`window-resize-handle window-resize-${direction}`}
+      onPointerDown={(event) => startResize(event, direction)}
+      onPointerMove={moveResize}
+      onPointerUp={stopResize}
+      onPointerCancel={stopResize}
+    />
+  ))
+}

--- a/src/renderer/src/help/Shortcuts.tsx
+++ b/src/renderer/src/help/Shortcuts.tsx
@@ -57,6 +57,7 @@ const getShortcutDescription = (action: string) => {
   const descriptionMap: Record<string, string> = {
     hideOrShowMainWindow: '隐藏/显示窗口',
     ignoreOrEnableMouse: '鼠标穿透(窗口对鼠标隐身)',
+    toggleWindowResizable: '开启/关闭窗口大小调整',
     increaseOpacity: '提高不透明度(窗口更清晰)',
     decreaseOpacity: '提高透明度(窗口更透明)',
     takeScreenshot: '截图并生成解题建议（会新开对话）',

--- a/src/renderer/src/lib/store/settings.ts
+++ b/src/renderer/src/lib/store/settings.ts
@@ -73,6 +73,8 @@ interface Settings {
   activeSceneId: string
 
   opacity: number
+  /** Allow resizing the main window and overlay toolbar */
+  resizable: boolean
   /** Show the click-through overlay toolbar above the main window */
   showOverlayToolbar: boolean
   /** Dwell time in ms before hovering a toolbar button fires it; 0 disables hover triggering */
@@ -110,6 +112,7 @@ const defaultSettings: Settings = {
   activeSceneId: CODING_SCENE_ID,
 
   opacity: 0.8,
+  resizable: true,
   showOverlayToolbar: true,
   toolbarHoverDelay: 1000,
 
@@ -183,9 +186,10 @@ export const useSettingsStore = create<SettingsStore>()(
     }),
     {
       name: 'interview-coder-settings',
-      version: 8,
+      version: 9,
       migrate: (persisted, version) => {
         const state = persisted as Partial<Settings>
+        if (version < 9) state.resizable = true
         // Drop the legacy codeLanguage field (language now lives in the prompt text)
         delete (state as Record<string, unknown>).codeLanguage
         if (version < 8) {

--- a/src/renderer/src/lib/store/shortcuts.ts
+++ b/src/renderer/src/lib/store/shortcuts.ts
@@ -46,6 +46,11 @@ const defaultShortcuts: Record<string, Omit<Shortcut, 'defaultKey'>> = {
     key: `${platformAlt}+M`,
     category: 'Window Management'
   },
+  toggleWindowResizable: {
+    action: 'toggleWindowResizable',
+    key: `${platformAlt}+R`,
+    category: 'Window Management'
+  },
   increaseOpacity: {
     action: 'increaseOpacity',
     key: `${platformAlt}+Shift+Up`,
@@ -138,7 +143,7 @@ export const useShortcutsStore = create<ShortcutsStore>()(
     }),
     {
       name: 'interview-coder-shortcuts',
-      version: 5,
+      version: 6,
       migrate: (state: unknown, version: number) => {
         if (!isPersistedShortcutsState(state) || !state.shortcuts) return state as ShortcutsStore
         // Merge in any new default shortcuts that are missing

--- a/src/renderer/src/lib/toolbar-actions.ts
+++ b/src/renderer/src/lib/toolbar-actions.ts
@@ -10,6 +10,7 @@ import {
   ImagePlus,
   Mic,
   MousePointer2,
+  Scaling,
   Sun,
   SunDim,
   type LucideIcon
@@ -36,6 +37,7 @@ export const TOOLBAR_ACTIONS: ToolbarAction[] = [
   { action: 'appendScreenshot', Icon: ImagePlus, label: '追加截图' },
   { action: 'stopSolutionStream', Icon: CircleStop, label: '停止生成' },
   { action: 'ignoreOrEnableMouse', Icon: MousePointer2, label: '切换鼠标穿透' },
+  { action: 'toggleWindowResizable', Icon: Scaling, label: '切换窗口大小调整' },
   { action: 'pageUp', Icon: ChevronUp, label: '向上翻页' },
   { action: 'pageDown', Icon: ChevronDown, label: '向下翻页' },
   { action: 'moveMainWindowUp', Icon: ArrowUp, label: '向上移动窗口' },

--- a/src/renderer/src/settings/CustomShortcuts.tsx
+++ b/src/renderer/src/settings/CustomShortcuts.tsx
@@ -67,6 +67,11 @@ export function CustomShortcuts() {
             shortcut="ignoreOrEnableMouse"
           />
           <Shortcut
+            label="调整窗口大小"
+            description="开启或关闭主窗口和上方悬浮工具条的边缘拖动调整"
+            shortcut="toggleWindowResizable"
+          />
+          <Shortcut
             label="提高不透明度"
             description="每次调整 5%，窗口更清晰"
             shortcut="increaseOpacity"

--- a/src/renderer/src/settings/index.tsx
+++ b/src/renderer/src/settings/index.tsx
@@ -50,6 +50,7 @@ import {
 export default function SettingsPage() {
   const {
     opacity,
+    resizable,
     showOverlayToolbar,
     toolbarHoverDelay,
     apiBaseURL,
@@ -456,6 +457,20 @@ export default function SettingsPage() {
                 />
                 <span className="text-xs whitespace-nowrap">不透明</span>
               </div>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium">
+                允许调整窗口大小
+                <span className="ml-2 text-xs font-light">
+                  同时应用于主窗口和上方悬浮工具条
+                </span>
+              </label>
+              <Switch
+                className="scale-y-90"
+                checked={resizable}
+                onCheckedChange={(checked) => updateSetting('resizable', checked)}
+              />
             </div>
 
             <div className="flex items-center justify-between">


### PR DESCRIPTION
## 背景与原因

应用使用无边框透明窗口。此前窗口默认允许拖动边缘调整大小，因此即使用户并不想缩放窗口，只要鼠标在操作过程中晃到主窗口或上方悬浮工具条的边缘，光标就会突然变成双向缩放光标。

本次更新增加“允许调整窗口大小”开关：

- **开启时**：鼠标移到窗口边缘会显示缩放光标，可以拖动边缘或四角调整大小；
- **关闭时**：窗口边缘不再响应缩放，鼠标晃到边缘也不会变成缩放光标；
- 该设置同时作用于主窗口和上方悬浮工具条；
- 默认保持开启，避免改变现有用户原本可调整窗口大小的使用习惯。

## 更新内容

- 在“设置 → 界面设置”中新增“允许调整窗口大小”开关，并持久化用户选择；
- 为主窗口和上方悬浮工具条增加八方向边缘/四角拖动调整；
- 关闭开关后移除缩放命中区域及对应缩放光标；
- 上方悬浮工具条新增窗口大小调整按钮，可直接切换开关；
- 新增可自定义的全局快捷键：
  - Windows/Linux：`Ctrl + R`
  - macOS：`Alt + R`
- 同步更新快捷键设置页和帮助页面。

## 实现说明

Electron 37 在 Windows 的透明无边框窗口上动态执行 `setResizable(false)` 后再恢复为 `true`，可能破坏窗口的分层透明效果，表现为窗口异常变亮、不透明或透明度调节失效。

因此本次没有升级 Electron，也没有在运行时切换原生 `setResizable()`。两个窗口保持关闭原生缩放，通过 renderer 中的边缘命中区域监听指针拖动，再经 preload IPC 由 main 进程更新 `BrowserWindow` bounds。关闭设置时直接不渲染这些命中区域，从根源上避免边缘缩放光标出现，同时不会触发透明窗口回归。

## 验证

- [x] 手动验证默认允许调整窗口大小；
- [x] 手动验证开关开启时，主窗口及悬浮工具条边缘/四角均可缩放；
- [x] 手动验证开关关闭时，鼠标移到边缘不再出现缩放光标且无法拖动缩放；
- [x] 手动验证关闭后重新开启不会导致窗口变亮或透明度失效；
- [x] 验证悬浮工具栏按钮和全局快捷键可切换设置；
- [x] `npm run build`；
- [x] TypeScript / LSP diagnostics：0；
- [x] `git diff --check`。