### PR TITLE
fix: 禁用后台节流，修复软隐藏后快捷键与工具条悬停失效

### DIFF
--- a/src/main/main-window.ts
+++ b/src/main/main-window.ts
@@ -33,7 +33,12 @@ export function createWindow(): void {
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
-      sandbox: false
+      sandbox: false,
+      // Soft-hide parks the window off-screen, which makes Windows report the
+      // window as occluded; with throttling on, the renderer freezes until the
+      // window is focused again (queued IPC flushes on click, toolbar hover
+      // dwell timers never fire).
+      backgroundThrottling: false
     }
   })
 

--- a/src/main/toolbar-window.ts
+++ b/src/main/toolbar-window.ts
@@ -35,7 +35,10 @@ export function createToolbarWindow(parent: BrowserWindow): void {
     parent,
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
-      sandbox: false
+      sandbox: false,
+      // Hover dwell runs on setTimeout in this renderer; it must not be
+      // throttled while the window is hidden/occluded (see main-window.ts).
+      backgroundThrottling: false
     }
   })
   ownerWindow = parent


### PR DESCRIPTION
## 问题现象

Windows 上使用「显示/隐藏窗口」快捷键隐藏窗口后再显示：

- 除「窗口移动」外，所有全局快捷键（截图、追问、透明度、翻页、转写等）失效
- 悬浮工具条的鼠标悬停（dwell）失效
- 必须手动点击窗口聚焦后才恢复，且失效期间按下的操作会在聚焦瞬间**全部一次性执行**

## 根因分析

Windows 上「隐藏窗口」采用软隐藏实现（`softHideWindow`）：不调用 `hide()`，而是 `setOpacity(0)` + 将窗口**移动到所有显示器之外**（`x = 屏幕最右缘 + 2000`）。

这会触发 Chromium 的原生窗口遮挡检测（`CalculateNativeWinOcclusion`，Windows 默认启用）：窗口完全离屏 → 判定为 occluded → 渲染进程进入后台节流/冻结状态（定时器钳制、任务队列暂停）。

恢复显示时 `restoreSoftHiddenWindow` 只把窗口搬回屏幕，但 **occlusion 状态不会随位置变化自动重算，要等窗口被激活/聚焦才重算**。因此两个渲染进程（主窗口 + 工具条）在恢复后仍处于冻结状态，直到用户点击聚焦。

各症状的对应关系：

| 症状 | 原因 |
|------|------|
| 快捷键失效 | `globalShortcut` 回调在主进程**照常执行**（截图已写盘、AI 请求已发出），但 `webContents.send()` 的 IPC 在冻结的渲染进程中排队 |
| 点击后全部立刻执行 | 聚焦 → 遮挡状态重算 → 渲染进程解冻 → 排队的 IPC 一次性刷出 |
| 窗口移动一直有效 | `moveMainWindow*` 是唯一纯主进程操作（仅 `setPosition`），不依赖渲染进程、不检查 `state.inCoderPage` |
| 工具条悬停失效 | dwell 判定基于工具条渲染进程内的 `setTimeout`（`OverlayToolbar.tsx`），被节流钳制 |

**隐蔽性**：失效期间按的截图键实际已完成截图写盘和 AI 请求（产生了 API 调用），只是界面未刷新。

## 修复

为主窗口与工具条窗口的 `webPreferences` 设置 `backgroundThrottling: false`。悬浮窗类应用需要渲染进程在隐藏/遮挡期间保持响应。

## 测试

Windows 11 + Electron 37 实测：修复前可稳定复现上述现象；加上本改动后，隐藏 → 显示 → 直接使用快捷键与工具条悬停均正常，无需点击聚焦。